### PR TITLE
❌🌲Make callbackDispatcher optional in the initializer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.html dartdoc-generated
+*.json dartdoc-generated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,3 +33,8 @@
 
 * Expose a WorkManagerHelper to the native.
   * This makes it easier if you also have some native code that wants to schedule the Echo Worker
+  
+# 0.0.7
+
+* If no `callbackDispatcher` is provided it will look for method with the name `callbackDispatcher` in the `main.dart` file.
+  You can still provide your own.  

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ An example of where this would be handy is when you have periodic job that fetch
 
 ```
 dependencies:
-  workmanager: ^0.0.6
+  workmanager: ^0.0.7
 ```
 
 Get it
@@ -30,30 +30,24 @@ import 'package:workmanager/workmanager.dart';
 ```
 
 # How to use
-
 See sample folder for a complete working example.
 
-Before you can register any jobs you need to initialize the plugin.
+# Initialization
+In your `main.dart` file define a top level function called `callbackDispatcher`.  
+This function will be called by Android and will return the value you provided when you registered the task.  
+
+Use the `WorkManager` helper function `WorkManager.defaultCallbackDispatcher` to register a callback.   
+Your sole responsibility is to either `true` of `false`;   
+Whether the background job failed or not. 
 
 ```
-//Provide a top level function or static function.
-//This function will be called by Android and will return the value you provided when you registered the task.
-//See below
 void callbackDispatcher() {
   Workmanager.defaultCallbackDispatcher((echoValue) {
-    print("Native echoed: $echoValue");
+    print("hello from the default callbackDispatcher");
     return Future.value(true);
   });
 }
-
-Workmanager.initialize(
-    callbackDispatcher, //the top level function.
-    isInDebugMode: true //If enabled it will post a notificiation whenever the job is running. Handy for debugging jobs
-)
-```
-
-> The `callbackDispatcher` needs to be either a static function or a top level function for it to work.
-> You should return a boolean value whether the job was successful or not. 
+``` 
 
 Now you can register two different kinds of background work:
 - **One off task**: These run once
@@ -80,6 +74,27 @@ You can use this `String` to identify which work needs to be done.
 
 ## Customisation
 Not every `WorkManager` feature is ported.
+
+### Custom callbackDispatcher function
+If for one reason you don't want the `callbackDispatcher` in your `main.dart` file or you don't want it to be called `callbackDispatcher`, you can set a custom one.
+
+Define a top level function or static function anywhere inside your project, name it anything you want.  
+```
+void myCustomCallbackDispatcher() {
+  Workmanager.defaultCallbackDispatcher((echoValue) {
+    print("Native echoed: $echoValue");
+    return Future.value(true);
+  });
+}
+
+Workmanager.initialize(
+    myCustomCallbackDispatcher, //the top level function.
+    isInDebugMode: true //If enabled it will post a notificiation whenever the job is running. Handy for debugging jobs
+)
+```
+
+> The `callbackDispatcher` needs to be either a static function or a top level function for it to work.
+> You should return a boolean value whether the job was successful or not. 
 
 ### Tagging
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ See sample folder for a complete working example.
 
 # Initialization
 In your `main.dart` file define a top level function called `callbackDispatcher`.  
-This function will be called by Android and will return the value you provided when you registered the task.  
+This function will be called once a background job completes and will return the value you provided when you registered the task.  
 
 Use the `WorkManager` helper function `WorkManager.defaultCallbackDispatcher` to register a callback.   
 Your sole responsibility is to either `true` of `false`;   

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ See sample folder for a complete working example.
 In your `main.dart` file define a top level function called `callbackDispatcher`.  
 This function will be called once a background job completes and will return the value you provided when you registered the task.  
 
-Use the `WorkManager` helper function `WorkManager.defaultCallbackDispatcher` to register a callback.   
-Your sole responsibility is to either `true` of `false`;   
+Use the `WorkManager` helper function `WorkManager#defaultCallbackDispatcher` to register a callback.   
+Your sole responsibility is to either return `true` of `false`;   
 Whether the background job failed or not. 
 
 ```
@@ -76,9 +76,10 @@ You can use this `String` to identify which work needs to be done.
 Not every `WorkManager` feature is ported.
 
 ### Custom callbackDispatcher function
-If for one reason you don't want the `callbackDispatcher` in your `main.dart` file or you don't want it to be called `callbackDispatcher`, you can set a custom one.
+If for one reason you don't want the `callbackDispatcher` in your `main.dart` file or you don't want it to be called `callbackDispatcher`, you can set your custom one.
 
 Define a top level function or static function anywhere inside your project, name it anything you want.  
+Pass it to the `initialize` function before registering any jobs.  
 ```
 void myCustomCallbackDispatcher() {
   Workmanager.defaultCallbackDispatcher((echoValue) {

--- a/android/src/main/kotlin/be/tramckrijte/workmanager/DebugHelper.kt
+++ b/android/src/main/kotlin/be/tramckrijte/workmanager/DebugHelper.kt
@@ -6,7 +6,6 @@ import android.content.Context
 import android.os.Build
 import androidx.core.app.NotificationCompat
 import androidx.work.ListenableWorker
-import io.flutter.view.FlutterCallbackInformation
 
 object DebugHelper {
     private const val debugChannelId = "WorkmanagerDebugChannelId"
@@ -16,7 +15,7 @@ object DebugHelper {
         postNotification(ctx, "$title ${System.currentTimeMillis()}", "${result.javaClass.simpleName}: $echoValue")
     }
 
-    fun postTaskStarting(ctx: Context, echoValue: String, callbackHandle: Long, callbackInfo: FlutterCallbackInformation?, dartBundlePath: String?) {
+    fun postTaskStarting(ctx: Context, echoValue: String, callbackHandle: Long, callbackInfo: FlutterCallbackInformationWrapper?, dartBundlePath: String?) {
         postNotification(ctx, echoValue, "" +
                 "callbackHandle: $callbackHandle;\n" +
                 "callBackName: ${callbackInfo?.callbackName};\n" +

--- a/android/src/main/kotlin/be/tramckrijte/workmanager/Extractor.kt
+++ b/android/src/main/kotlin/be/tramckrijte/workmanager/Extractor.kt
@@ -43,11 +43,11 @@ data class BackoffPolicyTaskConfig(val backoffPolicy: BackoffPolicy,
                 )
 
         val defaultOneOffBackoffTaskConfig =
-                 BackoffPolicyTaskConfig(
-                         defaultBackOffPolicy,
-                         defaultRequestedBackoffDelay,
-                         defaultRequestedBackoffDelay
-                 )
+                BackoffPolicyTaskConfig(
+                        defaultBackOffPolicy,
+                        defaultRequestedBackoffDelay,
+                        defaultRequestedBackoffDelay
+                )
     }
 }
 
@@ -153,7 +153,7 @@ object Extractor {
 
     fun extractWorkManagerCallFromRawMethodName(call: MethodCall): WorkManagerCall =
             when (PossibleWorkManagerCall.fromRawMethodName(call.method)) {
-                Extractor.PossibleWorkManagerCall.INITIALIZE -> WorkManagerCall.Initialize(call.arguments() as Long)
+                Extractor.PossibleWorkManagerCall.INITIALIZE -> WorkManagerCall.Initialize(extractCallbackHandleFromCall(call))
                 Extractor.PossibleWorkManagerCall.REGISTER_ONE_OFF_TASK -> {
                     WorkManagerCall.RegisterTask.OneOffTask(
                             isInDebugMode = call.argument<Boolean>(REGISTER_TASK_IS_IN_DEBUG_MODE_KEY)!!,
@@ -185,6 +185,13 @@ object Extractor {
                 Extractor.PossibleWorkManagerCall.CANCEL_ALL -> WorkManagerCall.CancelTask.All
 
                 Extractor.PossibleWorkManagerCall.UNKNOWN -> WorkManagerCall.Unknown
+            }
+
+    private fun extractCallbackHandleFromCall(call: MethodCall) =
+            try {
+                call.arguments() as Long
+            } catch (ignored: Exception) {
+                -1L
             }
 
     private fun extractExistingWorkPolicyFromCall(call: MethodCall): ExistingWorkPolicy =

--- a/android/src/main/kotlin/be/tramckrijte/workmanager/SharedPreferenceHelper.kt
+++ b/android/src/main/kotlin/be/tramckrijte/workmanager/SharedPreferenceHelper.kt
@@ -15,10 +15,6 @@ object SharedPreferenceHelper {
                 .apply()
     }
 
-    fun getCallbackHandle(ctx: Context): Long {
-
-        return ctx.prefs().getLong(CALLBACK_DISPATCHER_HANDLE_KEY, -1L)
-    }
-
-    fun hasCallbackHandle(ctx: Context) = ctx.prefs().contains(CALLBACK_DISPATCHER_HANDLE_KEY)
+    fun getCallbackHandle(ctx: Context): Long =
+            ctx.prefs().getLong(CALLBACK_DISPATCHER_HANDLE_KEY, -1L)
 }

--- a/android/src/main/kotlin/be/tramckrijte/workmanager/WorkmanagerCallHandler.kt
+++ b/android/src/main/kotlin/be/tramckrijte/workmanager/WorkmanagerCallHandler.kt
@@ -36,24 +36,6 @@ private object InitializeHandler : CallHandler<WorkManagerCall.Initialize> {
 
 private object RegisterTaskHandler : CallHandler<WorkManagerCall.RegisterTask> {
     override fun handle(context: Context, convertedCall: WorkManagerCall.RegisterTask, result: MethodChannel.Result) {
-        if (!SharedPreferenceHelper.hasCallbackHandle(context)) {
-            result.error(
-                    "1",
-                    "You have not properly initialized the Flutter WorkManager Package. " +
-                            "You should ensure you have called the 'initialize' function first! " +
-                            "Example: \n" +
-                            "\n" +
-                            "`Workmanager.initialize(\n" +
-                            "  callbackDispatcher,\n" +
-                            " )`" +
-                            "\n" +
-                            "\n" +
-                            "The `callbackDispatcher` is a top level function. See example in repository.",
-                    null
-            )
-            return
-        }
-
         when (convertedCall) {
             is WorkManagerCall.RegisterTask.OneOffTask -> enqueueOneOffTask(context, convertedCall)
             is WorkManagerCall.RegisterTask.PeriodicTask -> enqueuePeriodicTask(context, convertedCall)

--- a/doc/api/__404error.html
+++ b/doc/api/__404error.html
@@ -86,7 +86,7 @@
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/index.html
+++ b/doc/api/index.html
@@ -67,33 +67,38 @@
   <div id="dartdoc-main-content" class="col-xs-12 col-sm-9 col-md-8 main-content">
       <section class="desc markdown">
         <h1 id="flutter-workmanager">Flutter Workmanager</h1>
+<p><a href="https://pub.dartlang.org/packages/workmanager"><img src="https://img.shields.io/pub/v/workmanager.svg" alt="pub package"></a></p>
 <p>Flutter WorkManager is a wrapper around <a href="https://developer.android.com/topic/libraries/architecture/workmanager">Android's WorkManager</a>.<br>
 It allows for headless background work to be processed in Dart.  </p>
 <p>An example of where this would be handy is when you have periodic job that fetches the latest articles every hour.  </p>
 <blockquote>
 <p>Note that this library only contains the necessary code to let this work on Android. Since iOS has a vastly different approach you should therefore wrap every call:  </p>
 <p><code>if (Platform.isAndroid) { ... }</code></p></blockquote>
+<h1 id="installation">Installation</h1>
+<pre class="language-dart"><code>dependencies:
+  workmanager: ^0.0.7
+</code></pre>
+<p>Get it</p>
+<pre class="language-dart"><code>flutter pub get
+</code></pre>
+<p>Import it</p>
+<pre class="language-dart"><code>import 'package:workmanager/workmanager.dart';
+</code></pre>
 <h1 id="how-to-use">How to use</h1>
 <p>See sample folder for a complete working example.</p>
-<p>Before you can register any jobs you need to initialize the plugin.</p>
-<pre class="language-dart"><code>//Provide a top level function or static function.
-//This function will be called by Android and will return the value you provided when you registered the task.
-//See below
-void callbackDispatcher() {
+<h1 id="initialization">Initialization</h1>
+<p>In your <code>main.dart</code> file define a top level function called <code>callbackDispatcher</code>.<br>
+This function will be called once a background job completes and will return the value you provided when you registered the task.  </p>
+<p>Use the <code>WorkManager</code> helper function <code>WorkManager#defaultCallbackDispatcher</code> to register a callback.<br>
+Your sole responsibility is to either return <code>true</code> of <code>false</code>;<br>
+Whether the background job failed or not. </p>
+<pre class="language-dart"><code>void callbackDispatcher() {
   Workmanager.defaultCallbackDispatcher((echoValue) {
-    print("Native echoed: $echoValue");
+    print("hello from the default callbackDispatcher");
     return Future.value(true);
   });
 }
-
-Workmanager.initialize(
-    callbackDispatcher, //the top level function.
-    isInDebugMode: true //If enabled it will post a notificiation whenever the job is running. Handy for debugging jobs
-)
 </code></pre>
-<blockquote>
-<p>The <code>callbackDispatcher</code> needs to be either a static function or a top level function for it to work.
-You should return a boolean value whether the job was successful or not. </p></blockquote>
 <p>Now you can register two different kinds of background work:</p><ul><li><strong>One off task</strong>: These run once</li><li><strong>Periodic tasks</strong>: These run indefinitely with a defined fixed rate</li></ul>
 <pre class="language-dart"><code>// One off task registration
 Workmanager.registerOneOffTask(
@@ -113,6 +118,25 @@ The second parameter is the <code>String</code> that will be returned to your <c
 You can use this <code>String</code> to identify which work needs to be done.  </p>
 <h2 id="customisation">Customisation</h2>
 <p>Not every <code>WorkManager</code> feature is ported.</p>
+<h3 id="custom-callbackdispatcher-function">Custom callbackDispatcher function</h3>
+<p>If for one reason you don't want the <code>callbackDispatcher</code> in your <code>main.dart</code> file or you don't want it to be called <code>callbackDispatcher</code>, you can set your custom one.</p>
+<p>Define a top level function or static function anywhere inside your project, name it anything you want.<br>
+Pass it to the <code>initialize</code> function before registering any jobs.  </p>
+<pre class="language-dart"><code>void myCustomCallbackDispatcher() {
+  Workmanager.defaultCallbackDispatcher((echoValue) {
+    print("Native echoed: $echoValue");
+    return Future.value(true);
+  });
+}
+
+Workmanager.initialize(
+    myCustomCallbackDispatcher, //the top level function.
+    isInDebugMode: true //If enabled it will post a notificiation whenever the job is running. Handy for debugging jobs
+)
+</code></pre>
+<blockquote>
+<p>The <code>callbackDispatcher</code> needs to be either a static function or a top level function for it to work.
+You should return a boolean value whether the job was successful or not. </p></blockquote>
 <h3 id="tagging">Tagging</h3>
 <p>You can set the optional <code>tag</code> property.<br>
 Handy for cancellation by <code>tag</code>.<br>
@@ -247,7 +271,7 @@ communicating only via messages. <a href="dart-isolate/dart-isolate-library.html
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/BackoffPolicy-class.html
+++ b/doc/api/workmanager/BackoffPolicy-class.html
@@ -224,7 +224,7 @@ Backoff policies are set in WorkRequest.Builder.setBackoffCriteria(BackoffPolicy
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/BackoffPolicy/toString.html
+++ b/doc/api/workmanager/BackoffPolicy/toString.html
@@ -101,7 +101,7 @@
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/EchoCallbackFunction.html
+++ b/doc/api/workmanager/EchoCallbackFunction.html
@@ -96,7 +96,7 @@
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/ExistingWorkPolicy-class.html
+++ b/doc/api/workmanager/ExistingWorkPolicy-class.html
@@ -234,7 +234,7 @@
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/ExistingWorkPolicy/toString.html
+++ b/doc/api/workmanager/ExistingWorkPolicy/toString.html
@@ -102,7 +102,7 @@
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/NetworkType-class.html
+++ b/doc/api/workmanager/NetworkType-class.html
@@ -258,7 +258,7 @@
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/NetworkType/toString.html
+++ b/doc/api/workmanager/NetworkType/toString.html
@@ -104,7 +104,7 @@
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/WorkManagerConstraintConfig-class.html
+++ b/doc/api/workmanager/WorkManagerConstraintConfig-class.html
@@ -233,7 +233,7 @@ for example, when you have an unmetered network and are charging.</p>
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/WorkManagerConstraintConfig/WorkManagerConstraintConfig.html
+++ b/doc/api/workmanager/WorkManagerConstraintConfig/WorkManagerConstraintConfig.html
@@ -108,7 +108,7 @@
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/WorkManagerConstraintConfig/networkType.html
+++ b/doc/api/workmanager/WorkManagerConstraintConfig/networkType.html
@@ -106,7 +106,7 @@
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/WorkManagerConstraintConfig/requiresBatteryNotLow.html
+++ b/doc/api/workmanager/WorkManagerConstraintConfig/requiresBatteryNotLow.html
@@ -106,7 +106,7 @@
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/WorkManagerConstraintConfig/requiresCharging.html
+++ b/doc/api/workmanager/WorkManagerConstraintConfig/requiresCharging.html
@@ -106,7 +106,7 @@
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/WorkManagerConstraintConfig/requiresDeviceIdle.html
+++ b/doc/api/workmanager/WorkManagerConstraintConfig/requiresDeviceIdle.html
@@ -106,7 +106,7 @@
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/WorkManagerConstraintConfig/requiresStorageNotLow.html
+++ b/doc/api/workmanager/WorkManagerConstraintConfig/requiresStorageNotLow.html
@@ -106,7 +106,7 @@
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/Workmanager-class.html
+++ b/doc/api/workmanager/Workmanager-class.html
@@ -191,14 +191,14 @@
                   
 </dd>
         <dt id="initialize" class="callable">
-          <span class="name"><a href="workmanager/Workmanager/initialize.html">initialize</a></span><span class="signature">(<wbr><span class="parameter" id="initialize-param-callbackDispatcher"><span class="type-annotation"><a href="dart-core/Function-class.html">Function</a></span> <span class="parameter-name">callbackDispatcher</span>, {</span> <span class="parameter" id="initialize-param-isInDebugMode"><span class="type-annotation"><a href="dart-core/bool-class.html">bool</a></span> <span class="parameter-name">isInDebugMode</span></span> })
+          <span class="name"><a href="workmanager/Workmanager/initialize.html">initialize</a></span><span class="signature">(<wbr>{<span class="parameter" id="initialize-param-callbackDispatcher"><span class="type-annotation"><a href="dart-core/Function-class.html">Function</a></span> <span class="parameter-name">callbackDispatcher</span>, </span> <span class="parameter" id="initialize-param-isInDebugMode"><span class="type-annotation"><a href="dart-core/bool-class.html">bool</a></span> <span class="parameter-name">isInDebugMode</span></span> })
             <span class="returntype parameter">&#8594; <a href="dart-async/Future-class.html">Future</a><span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span>
           </span>
                   </dt>
         <dd>
-          This call is required if you wish to use the WorkManager plugin.
-callbackDispatcher is a top level function which will be invoked by Android
-isInDebugMode true will post debug notifications with information about when a job should have run
+          Optional initializer of the WorkManager plugin.
+callbackDispatcher is a top level function which will be invoked. Default the plugin will look for a top level method inside your main file called callbackDispatcher. If you wish to override this behaviour you can pass in your own.
+isInDebugMode true will post debug notifications (on Android) with information about when a job should have run
                   
 </dd>
         <dt id="registerOneOffTask" class="callable">
@@ -265,7 +265,7 @@ a frequency is not required and will be defaulted to 15 minutes if not provided.
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/Workmanager/Workmanager.html
+++ b/doc/api/workmanager/Workmanager/Workmanager.html
@@ -102,7 +102,7 @@
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/Workmanager/cancelAll.html
+++ b/doc/api/workmanager/Workmanager/cancelAll.html
@@ -110,7 +110,7 @@
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/Workmanager/cancelByTag.html
+++ b/doc/api/workmanager/Workmanager/cancelByTag.html
@@ -110,7 +110,7 @@
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/Workmanager/cancelByUniqueName.html
+++ b/doc/api/workmanager/Workmanager/cancelByUniqueName.html
@@ -111,7 +111,7 @@
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/Workmanager/defaultCallbackDispatcher.html
+++ b/doc/api/workmanager/Workmanager/defaultCallbackDispatcher.html
@@ -115,7 +115,7 @@
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/Workmanager/initialize.html
+++ b/doc/api/workmanager/Workmanager/initialize.html
@@ -88,24 +88,24 @@
     <section class="multi-line-signature">
       <span class="returntype"><a href="dart-async/Future-class.html">Future</a><span class="signature">&lt;<wbr><span class="type-parameter">void</span>&gt;</span></span>
             <span class="name ">initialize</span>
-(<wbr><span class="parameter" id="initialize-param-callbackDispatcher"><span class="type-annotation"><a href="dart-core/Function-class.html">Function</a></span> <span class="parameter-name">callbackDispatcher</span>, {</span> <span class="parameter" id="initialize-param-isInDebugMode"><span class="type-annotation"><a href="dart-core/bool-class.html">bool</a></span> <span class="parameter-name">isInDebugMode</span></span> })
+(<wbr>{<span class="parameter" id="initialize-param-callbackDispatcher"><span class="type-annotation"><a href="dart-core/Function-class.html">Function</a></span> <span class="parameter-name">callbackDispatcher</span>, </span> <span class="parameter" id="initialize-param-isInDebugMode"><span class="type-annotation"><a href="dart-core/bool-class.html">bool</a></span> <span class="parameter-name">isInDebugMode</span></span> })
       
     </section>
     <section class="desc markdown">
-      <p>This call is required if you wish to use the WorkManager plugin.
-callbackDispatcher is a top level function which will be invoked by Android
-isInDebugMode true will post debug notifications with information about when a job should have run</p>
+      <p>Optional initializer of the WorkManager plugin.
+callbackDispatcher is a top level function which will be invoked. Default the plugin will look for a top level method inside your main file called callbackDispatcher. If you wish to override this behaviour you can pass in your own.
+isInDebugMode true will post debug notifications (on Android) with information about when a job should have run</p>
     </section>
     
     <section class="summary source-code" id="source">
       <h2><span>Implementation</span></h2>
-      <pre class="language-dart"><code class="language-dart">static Future&lt;void&gt; initialize(
-  final Function callbackDispatcher, {
+      <pre class="language-dart"><code class="language-dart">static Future&lt;void&gt; initialize({
+  final Function callbackDispatcher,
   final bool isInDebugMode,
 }) async {
   Workmanager._isInDebugMode = isInDebugMode;
-  final callback = PluginUtilities.getCallbackHandle(callbackDispatcher);
-  await _foregroundChannel.invokeMethod(&#39;initialize&#39;, callback.toRawHandle());
+  final callbackHandle = callbackDispatcher != null ? PluginUtilities.getCallbackHandle(callbackDispatcher).toRawHandle() : -1;
+  await _foregroundChannel.invokeMethod(&#39;initialize&#39;, callbackHandle);
 }</code></pre>
     </section>
 
@@ -118,7 +118,7 @@ isInDebugMode true will post debug notifications with information about when a j
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/Workmanager/registerOneOffTask.html
+++ b/doc/api/workmanager/Workmanager/registerOneOffTask.html
@@ -131,7 +131,7 @@ The echoValue is the value that will be returned in the <a href="workmanager/Ech
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/Workmanager/registerPeriodicTask.html
+++ b/doc/api/workmanager/Workmanager/registerPeriodicTask.html
@@ -134,7 +134,7 @@ a frequency is not required and will be defaulted to 15 minutes if not provided.
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/doc/api/workmanager/workmanager-library.html
+++ b/doc/api/workmanager/workmanager-library.html
@@ -169,7 +169,7 @@ Backoff policies are set in WorkRequest.Builder.setBackoffCriteria(BackoffPolicy
 
 <footer>
   <span class="no-break">
-    workmanager 0.0.2
+    workmanager 0.0.7
   </span>
 
   

--- a/example/lib/constants.dart
+++ b/example/lib/constants.dart
@@ -1,0 +1,4 @@
+const simpleTaskKey = "simpleTask";
+const simpleDelayedTask = "simpleDelayedTask";
+const simplePeriodicTask = "simplePeriodicTask";
+const simplePeriodic1HourTask = "simplePeriodic1HourTask";

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,34 +1,17 @@
-import 'package:flutter/material.dart';
 import 'dart:async';
 
+import 'package:flutter/material.dart';
 import 'package:workmanager/workmanager.dart';
+
+import 'constants.dart';
+import 'my_custom_callback_dispatcher.dart';
 
 void main() => runApp(MyApp());
 
-const simpleTaskKey = "simpleTask";
-const simpleDelayedTask = "simpleDelayedTask";
-const simplePeriodicTask = "simplePeriodicTask";
-const simplePeriodic1HourTask = "simplePeriodic1HourTask";
-
+//If you don't provide a customCallbackDispatcher this one will be called for you
 void callbackDispatcher() {
   Workmanager.defaultCallbackDispatcher((echoValue) {
-    print("Native echoed: $echoValue");
-
-    switch (echoValue) {
-      case simpleTaskKey:
-        print("$simpleTaskKey was executed");
-        break;
-      case simpleDelayedTask:
-        print("$simpleDelayedTask was executed");
-        break;
-      case simplePeriodicTask:
-        print("$simplePeriodicTask was executed");
-        break;
-      case simplePeriodic1HourTask:
-        print("$simplePeriodic1HourTask was executed");
-        break;
-    }
-
+    print("hello from the default callbackDispatcher");
     return Future.value(true);
   });
 }
@@ -54,14 +37,19 @@ class _MyAppState extends State<MyApp> {
               Text("Initialize the plugin first",
                   style: Theme.of(context).textTheme.headline),
               RaisedButton(
-                  child: Text("Start the Flutter background service first"),
+                  child: Text("Initialize the plugin in debug mode."),
+                  onPressed: () {
+                    Workmanager.initialize(isInDebugMode: true);
+                  }),
+              RaisedButton(
+                  child: Text(
+                      "Initialize the plugin with a custom `callbackDispatcher`."),
                   onPressed: () {
                     Workmanager.initialize(
-                      callbackDispatcher,
                       isInDebugMode: true,
+                      callbackDispatcher: customCallbackDispatcher,
                     );
                   }),
-
               Text("One Off Tasks",
                   style: Theme.of(context).textTheme.headline),
               //This job runs once.

--- a/example/lib/my_custom_callback_dispatcher.dart
+++ b/example/lib/my_custom_callback_dispatcher.dart
@@ -1,0 +1,26 @@
+import 'package:workmanager/workmanager.dart';
+
+import 'constants.dart';
+
+void customCallbackDispatcher() {
+  Workmanager.defaultCallbackDispatcher((echoValue) {
+    print("Native echoed: $echoValue");
+
+    switch (echoValue) {
+      case simpleTaskKey:
+        print("$simpleTaskKey was executed");
+        break;
+      case simpleDelayedTask:
+        print("$simpleDelayedTask was executed");
+        break;
+      case simplePeriodicTask:
+        print("$simplePeriodicTask was executed");
+        break;
+      case simplePeriodic1HourTask:
+        print("$simplePeriodic1HourTask was executed");
+        break;
+    }
+
+    return Future.value(true);
+  });
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -148,6 +148,6 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.0.6"
+    version: "0.0.7"
 sdks:
   dart: ">=2.2.2 <3.0.0"

--- a/lib/workmanager.dart
+++ b/lib/workmanager.dart
@@ -103,16 +103,16 @@ class Workmanager {
     _backgroundChannel.invokeMethod("backgroundChannelInitialized");
   }
 
-  /// This call is required if you wish to use the WorkManager plugin.
-  /// callbackDispatcher is a top level function which will be invoked by Android
-  /// isInDebugMode true will post debug notifications with information about when a job should have run
-  static Future<void> initialize(
-    final Function callbackDispatcher, {
+  /// Optional initializer of the WorkManager plugin.
+  /// callbackDispatcher is a top level function which will be invoked. Default the plugin will look for a top level method inside your main file called callbackDispatcher. If you wish to override this behaviour you can pass in your own.
+  /// isInDebugMode true will post debug notifications (on Android) with information about when a job should have run
+  static Future<void> initialize({
+    final Function callbackDispatcher,
     final bool isInDebugMode,
   }) async {
     Workmanager._isInDebugMode = isInDebugMode;
-    final callback = PluginUtilities.getCallbackHandle(callbackDispatcher);
-    await _foregroundChannel.invokeMethod('initialize', callback.toRawHandle());
+    final callbackHandle = callbackDispatcher != null ? PluginUtilities.getCallbackHandle(callbackDispatcher).toRawHandle() : -1;
+    await _foregroundChannel.invokeMethod('initialize', callbackHandle);
   }
 
   /// Schedule a one off task

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: workmanager
 description: Flutter Android Workmanager. This plugin allows you to schedule background work on Android with the Android WorkManager API.
-version: 0.0.6
+version: 0.0.7
 author: Tim Rijckaert <tim.rijckaert@gmail.com>
 homepage: https://github.com/timrijckaert/flutter_workmanager
 


### PR DESCRIPTION
- We look for a standard `callbackDispatcher` function inside the `main.dart` file and call that one if none was provided.
- update the example
- update the README.md
- up the version to `0.0.7`